### PR TITLE
FUniqueNetIdDrift construction fix

### DIFF
--- a/Source/Private/OnlineIdentityDrift.h
+++ b/Source/Private/OnlineIdentityDrift.h
@@ -100,10 +100,10 @@ private:
 	   void OnPlayerNameSet(bool success, const FString& name);
 
     /** Ids mapped to locally registered users */
-    TMap<int32, TSharedPtr<const FUniqueNetId>> UserIds;
+    TMap<int32, TSharedRef<FUniqueNetIdDrift>> UserIds;
 
     /** Ids mapped to locally registered users */
-    TMap<FUniqueNetIdDrift, TSharedRef<FUserOnlineAccountDrift>> UserAccounts;
+    TMap<DriftID, TSharedRef<FUserOnlineAccountDrift>> UserAccounts;
 
     FOnlineSubsystemDrift* DriftSubsystem;
 

--- a/Source/Private/OnlineSessionDrift.cpp
+++ b/Source/Private/OnlineSessionDrift.cpp
@@ -561,8 +561,7 @@ bool FOnlineSessionDrift::StartMatchmaking(const TArray< TSharedRef<const FUniqu
         FString token;
         if (SearchSettings->QuerySettings.Get(TEXT("friend_id"), friendId))
         {
-            FUniqueNetIdDrift driftId{ friendId };
-            drift->InvitePlayerToMatch(driftId.GetId(), FDriftJoinedMatchQueueDelegate::CreateRaw(this, &FOnlineSessionDrift::OnJoinedMatchQueue));
+            drift->InvitePlayerToMatch(FUniqueNetIdDrift::ParseDriftId(friendId), FDriftJoinedMatchQueueDelegate::CreateRaw(this, &FOnlineSessionDrift::OnJoinedMatchQueue));
         }
         else if (SearchSettings->QuerySettings.Get(TEXT("invite_token"), token))
         {
@@ -1036,9 +1035,7 @@ void FOnlineSessionDrift::UnregisterVoice(const FUniqueNetId& PlayerId)
 
 bool FOnlineSessionDrift::RegisterPlayer(FName SessionName, const FUniqueNetId& PlayerId, bool bWasInvited)
 {
-    TArray< TSharedRef<const FUniqueNetId> > Players;
-    Players.Add(MakeShareable(new FUniqueNetIdDrift(PlayerId)));
-    return RegisterPlayers(SessionName, Players, bWasInvited);
+    return RegisterPlayers(SessionName, { FUniqueNetIdDrift::Create(PlayerId) }, bWasInvited);
 }
 
 bool FOnlineSessionDrift::RegisterPlayers(FName SessionName, const TArray<TSharedRef<const FUniqueNetId>>& Players, bool bWasInvited)
@@ -1061,7 +1058,7 @@ bool FOnlineSessionDrift::RegisterPlayers(FName SessionName, const TArray<TShare
                 {
                     if (auto Drift = DriftSubsystem->GetDrift())
                     {
-                        Drift->AddPlayerToMatch(FUniqueNetIdDrift{ *PlayerId }.GetId(), 0, FDriftPlayerAddedDelegate::CreateLambda([this, SessionName, Players](bool success)
+                        Drift->AddPlayerToMatch(FUniqueNetIdDrift::ParseDriftId(*PlayerId), 0, FDriftPlayerAddedDelegate::CreateLambda([this, SessionName, Players](bool success)
                         {
                             if (success)
                             {
@@ -1104,9 +1101,7 @@ bool FOnlineSessionDrift::RegisterPlayers(FName SessionName, const TArray<TShare
 
 bool FOnlineSessionDrift::UnregisterPlayer(FName SessionName, const FUniqueNetId& PlayerId)
 {
-    TArray< TSharedRef<const FUniqueNetId> > Players;
-    Players.Add(MakeShareable(new FUniqueNetIdDrift(PlayerId)));
-    return UnregisterPlayers(SessionName, Players);
+    return UnregisterPlayers(SessionName, { FUniqueNetIdDrift::Create(PlayerId) });
 }
 
 bool FOnlineSessionDrift::UnregisterPlayers(FName SessionName, const TArray<TSharedRef<const FUniqueNetId>>& Players)
@@ -1129,7 +1124,7 @@ bool FOnlineSessionDrift::UnregisterPlayers(FName SessionName, const TArray<TSha
                 {
                     if (auto Drift = DriftSubsystem->GetDrift())
                     {
-                        Drift->RemovePlayerFromMatch(FUniqueNetIdDrift{ *PlayerId }.GetId(), FDriftPlayerRemovedDelegate::CreateLambda([this, SessionName, Players](bool success)
+                        Drift->RemovePlayerFromMatch(FUniqueNetIdDrift::ParseDriftId(*PlayerId), FDriftPlayerRemovedDelegate::CreateLambda([this, SessionName, Players](bool success)
                         {
                             if (success)
                             {

--- a/Source/Private/OnlineSubsystemDriftTypes.h
+++ b/Source/Private/OnlineSubsystemDriftTypes.h
@@ -85,38 +85,13 @@ public:
 
 using DriftID = uint32;
 
+typedef TSharedPtr<class FUniqueNetIdDrift> FUniqueNetIdDriftPtr;
+typedef TSharedRef<class FUniqueNetIdDrift> FUniqueNetIdDriftRef;
+
 class FUniqueNetIdDrift : public FUniqueNetId
 {
 public:
-    FUniqueNetIdDrift()
-    : driftId_{ 0 }
-    {
-    }
-
-    explicit FUniqueNetIdDrift(const FUniqueNetId& Src)
-    {
-        if (Src.GetSize() == sizeof(driftId_))
-        {
-            driftId_ = static_cast<const FUniqueNetIdDrift&>(Src).driftId_;
-        }
-    }
-
-    explicit FUniqueNetIdDrift(const FUniqueNetIdDrift& other)
-    : driftId_{ other.driftId_ }
-    {
-    }
-    
-    FUniqueNetIdDrift(uint32 driftId)
-    : driftId_{ driftId }
-    {
-    }
-
-    explicit FUniqueNetIdDrift(const FString& Str)
-    : driftId_(FCString::Atoi(*Str))
-    {
-    }
-	
-	FName GetType() const override
+    FName GetType() const override
 	{
 		return DRIFT_SUBSYSTEM;
 	}
@@ -151,11 +126,63 @@ public:
         return other.driftId_;
     }
 
-    uint32 GetId() const
+	DriftID GetId() const
     {
         return driftId_;
     }
 
+	static DriftID ParseDriftId(const FUniqueNetId& Src)
+	{
+		if (ensure(Src.GetType() == DRIFT_SUBSYSTEM))
+		{
+			return static_cast<const FUniqueNetIdDrift&>(Src).driftId_;
+		}
+		return 0;
+	}
+
+	static DriftID ParseDriftId(const FString& Str)
+	{
+		return FCString::Atoi(*Str);
+	}
+
+	static FUniqueNetIdDriftRef EmptyId()
+	{
+		static const auto DummyId = MakeShareable(new FUniqueNetIdDrift());
+		return DummyId;
+	}
+
+	template<class T>
+	static FUniqueNetIdDriftRef Create(const T& Src)
+	{
+		return MakeShareable(new FUniqueNetIdDrift(Src));
+	}
+
 private:
-    uint32 driftId_;
+	FUniqueNetIdDrift()
+		: driftId_{ 0 }
+	{
+	}
+
+	explicit FUniqueNetIdDrift(const FUniqueNetId& Src)
+		: driftId_{ ParseDriftId(Src) }
+	{
+	}
+
+	explicit FUniqueNetIdDrift(const FUniqueNetIdDrift& other)
+		: driftId_{ other.driftId_ }
+	{
+	}
+
+	FUniqueNetIdDrift(uint32 driftId)
+		: driftId_{ driftId }
+	{
+	}
+
+	explicit FUniqueNetIdDrift(const FString& Str)
+		: driftId_{ ParseDriftId(Str) }
+	{
+	}
+
+private:
+	DriftID driftId_;
 };

--- a/Source/Private/VoiceEngineDrift.cpp
+++ b/Source/Private/VoiceEngineDrift.cpp
@@ -217,7 +217,7 @@ uint32 FVoiceEngineDrift::StopLocalVoiceProcessing(uint32 LocalUserNum)
 
 uint32 FVoiceEngineDrift::UnregisterRemoteTalker(const FUniqueNetId& UniqueId)
 {
-	const FUniqueNetIdDrift& RemoteTalkerId = (const FUniqueNetIdDrift&)UniqueId;
+	const auto RemoteTalkerId = FUniqueNetIdDrift::ParseDriftId(UniqueId);
 	FRemoteTalkerDataDrift* RemoteData = RemoteTalkerBuffers.Find(RemoteTalkerId);
 	if (RemoteData != nullptr)
 	{
@@ -352,7 +352,7 @@ uint32 FVoiceEngineDrift::SubmitRemoteVoiceData(const FUniqueNetId& RemoteTalker
 {
 	UE_LOG(LogVoiceDecode, VeryVerbose, TEXT("SubmitRemoteVoiceData(%s) Size: %d received!"), *RemoteTalkerId.ToDebugString(), *Size);
 
-	const FUniqueNetIdDrift& TalkerId = (const FUniqueNetIdDrift&)RemoteTalkerId;
+	const auto TalkerId = FUniqueNetIdDrift::ParseDriftId(RemoteTalkerId);
 	FRemoteTalkerDataDrift& QueuedData = RemoteTalkerBuffers.FindOrAdd(TalkerId);
 
 	// new voice packet.
@@ -444,7 +444,7 @@ void FVoiceEngineDrift::OnAudioFinished(UAudioComponent* AC)
 		FRemoteTalkerDataDrift& RemoteData = It.Value();
 		if (!IsValid(RemoteData.AudioComponent) || AC == RemoteData.AudioComponent)
 		{
-			UE_LOG(LogVoiceDecode, Log, TEXT("Removing VOIP AudioComponent for Id: %s"), *It.Key().ToDebugString());
+			UE_LOG(LogVoiceDecode, Log, TEXT("Removing VOIP AudioComponent for Id: %d"), It.Key());
 			RemoteData.AudioComponent = nullptr;
 			break;
 		}

--- a/Source/Private/VoiceEngineDrift.h
+++ b/Source/Private/VoiceEngineDrift.h
@@ -88,7 +88,7 @@ class FVoiceEngineDrift : public IVoiceEngine
 	friend class FVoiceSerializeHelper;
 
 	/** Mapping of UniqueIds to the incoming voice data and their audio component */
-	typedef TMap<class FUniqueNetIdDrift, FRemoteTalkerDataDrift> FRemoteTalkerData;
+	typedef TMap<DriftID, FRemoteTalkerDataDrift> FRemoteTalkerData;
 
 	/** Reference to the main online subsystem */
 	class IOnlineSubsystem* OnlineSubsystem;
@@ -233,7 +233,7 @@ public:
 
 	virtual bool IsRemotePlayerTalking(const FUniqueNetId& UniqueId) override
 	{
-		return RemoteTalkerBuffers.Find((const FUniqueNetIdDrift&)UniqueId) != NULL;
+		return RemoteTalkerBuffers.Find(FUniqueNetIdDrift::ParseDriftId(UniqueId)) != NULL;
 	}
 
 	virtual uint32 GetVoiceDataReadyFlags() const override;

--- a/Source/Private/VoiceInterfaceDrift.h
+++ b/Source/Private/VoiceInterfaceDrift.h
@@ -32,9 +32,9 @@ class ONLINESUBSYSTEMDRIFT_API FOnlineVoiceDrift : public IOnlineVoice
 	/** State of all possible remote talkers */
 	TArray<FRemoteTalker> RemoteTalkers;
 	/** Remote players locally muted explicitly */
-	TArray<FUniqueNetIdDrift> SystemMuteList;
+	TArray<DriftID> SystemMuteList;
 	/** All remote players locally muted */
-	TArray<FUniqueNetIdDrift> MuteList;
+	TArray<DriftID> MuteList;
 
 	/** Time to wait for new data before triggering "not talking" */
 	float VoiceNotificationDelta;


### PR DESCRIPTION
- All the FUniqueNetId subclasses are expected to be constructed as shared object as they inherit from TSharedFromThis<>
- This is now enforced by privatizing the ctors of FUniqueNetIdDrift and providing a factory method to create the instances: FUniqueNetIdDrift::Create
- Replaced all the instances where FUniqueNetIdDrift was used as map key or array element to use the naked integer Drift Id instead (can't use FUniqueNetIdDrift as they can't be copied, can't use its shared ptr either as pointer hash/comparision is pointless for Drift Id equality check)